### PR TITLE
fix: LDoc type for float.toggle

### DIFF
--- a/lua/lir/float/init.lua
+++ b/lua/lir/float/init.lua
@@ -73,7 +73,7 @@ local function find_lir_float_win()
   return nil
 end
 
----@param dir string
+---@param dir string?
 function float.toggle(dir)
   local float_win = find_lir_float_win()
   if float_win then


### PR DESCRIPTION
Just a tiny fix on the type of `float.toggle` function.